### PR TITLE
Add GlobalAccountLocker in event emitter types

### DIFF
--- a/src/gateway/models.rs
+++ b/src/gateway/models.rs
@@ -515,6 +515,7 @@ pub enum EntityType {
     GlobalTwoResourcePool,
     GlobalMultiResourcePool,
     GlobalTransactionTracker,
+    GlobalAccountLocker,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Was missing and reported to me by Ripsource